### PR TITLE
Add filtering based on transport scheme of URL.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cookie-jar"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Curtis Millar <curtis@curtism.me>"]
 description = "Implementation of a RFC6265 compliant cookie store."
 repository = "https://github.com/xurtis/cookie-jar"

--- a/src/cookie/mod.rs
+++ b/src/cookie/mod.rs
@@ -571,17 +571,27 @@ impl<'u> From<&'u Url> for Scheme<'u> {
 }
 
 impl<'u> Scheme<'u> {
-    fn is_http(&self) -> bool {
+    pub(crate) fn is_http(&self) -> bool {
         match self {
             Scheme::Http | Scheme::Https => true,
             _ => false,
         }
     }
 
-    fn is_secure(&self) -> bool {
+    pub(crate) fn is_secure(&self) -> bool {
         match self {
             Scheme::Https => true,
             _ => false,
+        }
+    }
+
+    pub(crate) fn fulfils(&self, attributes: &Attributes) -> bool {
+        if attributes.secure() && !self.is_secure() {
+            false
+        } else if attributes.http_only() && !self.is_http() {
+            false
+        } else {
+            true
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,12 @@ error_chain!{
         HostInvalid {
             description("Invalid to provide an IP address for a SetCookie")
         }
+        InsecureOrigin {
+            description("A cookie with the `Secure` attribute was delivered over a non-TLS transport")
+        }
+        NonHttpOrigin {
+            description("A cookie with the `HttpOnly` attribute was delivered over a non-HTTP transport")
+        }
     }
 }
 

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -141,20 +141,6 @@ impl HostMatch {
     }
 }
 
-impl<'u> Scheme<'u> {
-    fn filter(self) -> impl (FnMut(&&Attributes) -> bool) + 'u {
-        move |attribute: &&Attributes| {
-            match (attribute.http_only(), attribute.secure(), self) {
-                (true, true, Scheme::Https) => true,
-                (true, false, Scheme::Https) => true,
-                (true, false, Scheme::Http) => true,
-                (false, false, _) => true,
-                _ => false,
-            }
-        }
-    }
-}
-
 /// The heirarchy of domains.
 #[derive(Debug, Default)]
 struct Domain {
@@ -226,8 +212,8 @@ impl Path {
         S: Iterator<Item = &'s str> + 's,
     {
         let iter = self.cookies.values()
+            .filter(move |attrs| transport.fulfils(attrs))
             .filter(host.filter())
-            .filter(transport.filter())
             .map(Attributes::pair);
 
         if let Some(child) = segments.next() {

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -18,7 +18,7 @@ use std::net::IpAddr;
 use url::{Url, Host};
 use time::{Tm, now_utc};
 
-use ::cookie::{Cookie, Attributes, Pair, url_dir_path};
+use ::cookie::{Cookie, Attributes, Pair, Scheme, url_dir_path};
 
 /// Something that produces the current UTC time.
 pub trait Clock {
@@ -137,24 +137,6 @@ impl HostMatch {
         move |attributes| match self {
             HostMatch::Exact => true,
             HostMatch::Suffix => !attributes.host_only(),
-        }
-    }
-}
-
-/// The transport scheme for a URI.
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum Scheme<'u> {
-    Http,
-    Https,
-    Other(&'u str),
-}
-
-impl<'u> From<&'u Url> for Scheme<'u> {
-    fn from(url: &'u Url) -> Scheme<'u> {
-        match url.scheme() {
-            "http" => Scheme::Http,
-            "https" => Scheme::Http,
-            scheme => Scheme::Other(scheme)
         }
     }
 }


### PR DESCRIPTION
`HttpOnly` cookies should only be used with URLs with a `"http"` scheme. (Fixes #1)
`Secure` cookies should only be used with URLs with a `"https"` scheme. (Fixes #2)

Similar checks should probably be done for parsing of cookies.